### PR TITLE
Apply another guard against "empty" autoscaling groups

### DIFF
--- a/salt/modules/boto_asg.py
+++ b/salt/modules/boto_asg.py
@@ -141,7 +141,7 @@ def get_config(name, region=None, key=None, keyid=None, profile=None):
     retries = 30
     while True:
         try:
-            asg = [g for g in conn.get_all_groups(names=[name]) if g.name]
+            asg = [g for g in conn.get_all_groups(names=[name]) if all([g.name, g.vpc_zone_identifier])]
             if asg:
                 asg = asg[0]
             else:
@@ -164,6 +164,7 @@ def get_config(name, region=None, key=None, keyid=None, profile=None):
                         _tag['propagate_at_launch'] = tag.propagate_at_launch
                         _tags.append(_tag)
                     ret['tags'] = _tags
+                # IT-101: This comment is misleading. We sometimes see a `None` returned.
                 # Boto accepts a string or list as input for vpc_zone_identifier,
                 # but always returns a comma separated list. We require lists in
                 # states.


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
